### PR TITLE
Return errors instead of exiting

### DIFF
--- a/graphql/all_commits.go
+++ b/graphql/all_commits.go
@@ -2,13 +2,13 @@ package graphql
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func AllCommits(client *githubv4.Client, user string, fromYear int, toYear int) []CommitContributions {
+func AllCommits(client *githubv4.Client, user string, fromYear int, toYear int) ([]CommitContributions, error) {
 	loc, _ := time.LoadLocation("Local")
 	_, month, day := time.Now().Date()
 	var m int = int(month)
@@ -23,8 +23,8 @@ func AllCommits(client *githubv4.Client, user string, fromYear int, toYear int) 
 	}
 	err := client.Query(context.Background(), &ContributionsQuery, variables)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("Couldn't get commits for %s: %w", user, err)
 	}
 
-	return ContributionsQuery.User.ContributionsCollection.CommitContributionsByRepository
+	return ContributionsQuery.User.ContributionsCollection.CommitContributionsByRepository, nil
 }

--- a/graphql/all_contributions.go
+++ b/graphql/all_contributions.go
@@ -2,13 +2,13 @@ package graphql
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func AllContributions(client *githubv4.Client, user string, fromYear int, toYear int) ContributionsCollection {
+func AllContributions(client *githubv4.Client, user string, fromYear int, toYear int) (c ContributionsCollection, err error) {
 	loc, _ := time.LoadLocation("Local")
 	_, month, day := time.Now().Date()
 	var m int = int(month)
@@ -22,10 +22,10 @@ func AllContributions(client *githubv4.Client, user string, fromYear int, toYear
 		"to":   githubv4.DateTime{Time: toDate},
 	}
 
-	err := client.Query(context.Background(), &ContributionsQuery, variables)
-	if err != nil {
-		log.Fatal(err)
+	clientErr := client.Query(context.Background(), &ContributionsQuery, variables)
+	if clientErr != nil {
+		return c, fmt.Errorf("Couldn't get contributions for %s: %w", user, clientErr)
 	}
 
-	return ContributionsQuery.User.ContributionsCollection
+	return ContributionsQuery.User.ContributionsCollection, nil
 }

--- a/graphql/all_issues.go
+++ b/graphql/all_issues.go
@@ -2,13 +2,13 @@ package graphql
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func AllIssues(client *githubv4.Client, user string, fromYear int, toYear int) []IssueContributions {
+func AllIssues(client *githubv4.Client, user string, fromYear int, toYear int) ([]IssueContributions, error) {
 	loc, _ := time.LoadLocation("Local")
 	_, month, day := time.Now().Date()
 	var m int = int(month)
@@ -24,8 +24,8 @@ func AllIssues(client *githubv4.Client, user string, fromYear int, toYear int) [
 
 	err := client.Query(context.Background(), &ContributionsQuery, variables)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("Couldn't get issues for %s: %w", user, err)
 	}
 
-	return ContributionsQuery.User.ContributionsCollection.IssueContributionsByRepository
+	return ContributionsQuery.User.ContributionsCollection.IssueContributionsByRepository, nil
 }

--- a/graphql/all_pull_requests.go
+++ b/graphql/all_pull_requests.go
@@ -2,13 +2,13 @@ package graphql
 
 import (
 	"context"
-	"log"
+	"fmt"
 	"time"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func AllPullRequests(client *githubv4.Client, user string, fromYear int, toYear int) []PullRequestContributions {
+func AllPullRequests(client *githubv4.Client, user string, fromYear int, toYear int) ([]PullRequestContributions, error) {
 	loc, _ := time.LoadLocation("Local")
 	_, month, day := time.Now().Date()
 	var m int = int(month)
@@ -24,8 +24,8 @@ func AllPullRequests(client *githubv4.Client, user string, fromYear int, toYear 
 
 	err := client.Query(context.Background(), &ContributionsQuery, variables)
 	if err != nil {
-		log.Fatal(err)
+		return nil, fmt.Errorf("Couldn't get pull requests for %s: %w", user, err)
 	}
 
-	return ContributionsQuery.User.ContributionsCollection.PullRequestContributionsByRepository
+	return ContributionsQuery.User.ContributionsCollection.PullRequestContributionsByRepository, nil
 }

--- a/graphql/languages_by_commit.go
+++ b/graphql/languages_by_commit.go
@@ -5,8 +5,12 @@ import (
 	"github.com/shurcooL/githubv4"
 )
 
-func LanguagesByCommit(client *githubv4.Client, user string, from int, to int) (languages []string, commitsNum []float64) {
-	commits := AllCommits(client, user, from, to)
+func LanguagesByCommit(client *githubv4.Client, user string, from int, to int) (
+	languages []string,
+	commitsNum []float64,
+	err error,
+) {
+	commits, err := AllCommits(client, user, from, to)
 
 	var langsSlice []string
 	var numsSlice []float64
@@ -24,5 +28,5 @@ func LanguagesByCommit(client *githubv4.Client, user string, from int, to int) (
 	languagesCommit := h.CountLanguagesCommit(langsSlice, numsSlice)
 	langs, count := h.SortMap(languagesCommit)
 
-	return langs, count
+	return langs, count, err
 }

--- a/graphql/organizations_details.go
+++ b/graphql/organizations_details.go
@@ -2,20 +2,20 @@ package graphql
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func OrganizationDetails(client *githubv4.Client, organization string) Organization {
+func OrganizationDetails(client *githubv4.Client, organization string) (org Organization, err error) {
 	variables := map[string]interface{}{
 		"user": githubv4.String(organization),
 	}
 
-	err := client.Query(context.Background(), &OrganizationQuery, variables)
-	if err != nil {
-		log.Fatal(err)
+	clientErr := client.Query(context.Background(), &OrganizationQuery, variables)
+	if clientErr != nil {
+		return org, fmt.Errorf("Couldn't get details for organization %s: %w", organization, clientErr)
 	}
 
-	return OrganizationQuery.Organization
+	return OrganizationQuery.Organization, nil
 }

--- a/graphql/user_details.go
+++ b/graphql/user_details.go
@@ -2,20 +2,20 @@ package graphql
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func UserDetails(client *githubv4.Client, user string) User {
+func UserDetails(client *githubv4.Client, user string) (innerUser User, err error) {
 	variables := map[string]interface{}{
 		"user": githubv4.String(user),
 	}
 
-	err := client.Query(context.Background(), &UserQuery, variables)
-	if err != nil {
-		log.Fatal(err)
+	clientErr := client.Query(context.Background(), &UserQuery, variables)
+	if clientErr != nil {
+		return innerUser, fmt.Errorf("Couldn't get user %s: %w", user, clientErr)
 	}
 
-	return UserQuery.User
+	return UserQuery.User, nil
 }

--- a/graphql/year_activity.go
+++ b/graphql/year_activity.go
@@ -2,21 +2,22 @@ package graphql
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/shurcooL/githubv4"
 )
 
-func YearActivity(client *githubv4.Client, user string) (dates []string, contribs []float64) {
+func YearActivity(client *githubv4.Client, user string) (dates []string, contribs []float64, err error) {
 	variables := map[string]interface{}{
 		"user":          githubv4.String(user),
 		"repoCount":     githubv4.Int(100),
 		"languageCount": githubv4.Int(100),
 	}
 
-	err := client.Query(context.Background(), &YearActivityQuery, variables)
-	if err != nil {
-		log.Fatal(err)
+	clientErr := client.Query(context.Background(), &YearActivityQuery, variables)
+	if clientErr != nil {
+		err = fmt.Errorf("Couldn't get year activity for %s: %w", user, clientErr)
+		return
 	}
 
 	var datesSlice []string
@@ -31,5 +32,5 @@ func YearActivity(client *githubv4.Client, user string) (dates []string, contrib
 		}
 	}
 
-	return datesSlice, contribsSlice
+	return datesSlice, contribsSlice, nil
 }

--- a/rest/all_repos.go
+++ b/rest/all_repos.go
@@ -2,21 +2,21 @@ package rest
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/google/go-github/v33/github"
 )
 
-func AllRepos(ctx context.Context, client *github.Client, account string) []*github.Repository {
+func AllRepos(ctx context.Context, client *github.Client, account string) (allRepos []*github.Repository, err error) {
 	opt := &github.RepositoryListOptions{
 		ListOptions: github.ListOptions{PerPage: 100},
 	}
 
-	var allRepos []*github.Repository
 	for {
-		repos, resp, err := client.Repositories.List(ctx, account, opt)
-		if err != nil {
-			log.Fatal(err)
+		repos, resp, clientErr := client.Repositories.List(ctx, account, opt)
+		if clientErr != nil {
+			err = fmt.Errorf("Couldn't get all repositories for %s: %w", account, clientErr)
+			break
 		}
 		allRepos = append(allRepos, repos...)
 		if resp.NextPage == 0 {
@@ -25,5 +25,5 @@ func AllRepos(ctx context.Context, client *github.Client, account string) []*git
 		opt.Page = resp.NextPage
 	}
 
-	return allRepos
+	return
 }


### PR DESCRIPTION
Instead of executing [`log.Fatal`](https://golang.org/pkg/log/#Fatal), which forces a binary to quit early, return `error` types so that code using this library can choose how error is handled.

Since this is a breaking change, it might be necessary to make a  release for before this PR, so that existing users won't get return type conflicts.

Resolves #1